### PR TITLE
Avoid Tab exception that breaks uninstall/enable/disable actions

### DIFF
--- a/gamification.php
+++ b/gamification.php
@@ -161,12 +161,39 @@ class gamification extends Module
 
     public function enable($force_all = false)
     {
-        return parent::enable($force_all) && Tab::enablingForModule($this->name);
+        $enabled = parent::enable($force_all);
+
+        if ($enabled) {
+            $tabCollection = Tab::getCollectionFromModule($this->name);
+
+            if ($tabCollection->count()) {
+                try {
+                    Tab::enablingForModule($this->name);
+                } catch (PrestaShopException $exception) {
+                    $this->uninstallTab();
+                    $this->installTab();
+                }
+            } else {
+                $this->installTab();
+            }
+        }
+
+        return $enabled;
     }
 
     public function disable($force_all = false)
     {
-        return parent::disable($force_all) && Tab::disablingForModule($this->name);
+        $disabled = parent::disable($force_all);
+
+        if ($disabled) {
+            try {
+                Tab::disablingForModule($this->name);
+            } catch (PrestaShopException $exception) {
+                $this->uninstallTab();
+            }
+        }
+
+        return $disabled;
     }
 
     public function getContent()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On `install` and `uninstall` actions `enable` and `disable` are also called by PrestaShop Core, it call `Tab::enablingForModule` and `Tab::disablingForModule`, if `Tab` name is invalid in a language, `Tab::save` thrown an exception `Property Tab->name is empty` that breaks actions
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShopCorp/gamification/issues/101
| How to test?  | Install Gamification module, Install a new Language, Set new language as employee language on profile, Uninstall Gamification module