### PR TITLE
[-] BO : Fix uninstall when DB_PREFIX is empty

### DIFF
--- a/gamification.php
+++ b/gamification.php
@@ -106,7 +106,7 @@ class gamification extends Module
     {
         $sql = include __DIR__ . '/sql_install.php';
         foreach ($sql as $name => $v) {
-            Db::getInstance()->execute('DROP TABLE ' . $name);
+            Db::getInstance()->execute('DROP TABLE `' . $name . '`');
         }
 
         return true;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes problem when uninstalling gamification module when DB_PREFIX is empty during installation
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | n/a
| How to test?  | Install prestashop without a DB_PREFIX, uninstall gamification module with bin/console. 


