### PR TITLE
Adding new countries and limitation to PS 1.7 for PS Paylater banner

### DIFF
--- a/gamification.php
+++ b/gamification.php
@@ -434,13 +434,13 @@ class gamification extends Module
     public function hookDisplayAdminAfterHeader()
     {
         // PrestaShop Paylater with PayPlug & Oney is available only from PrestaShop 1.7
-        if (version_compare(_PS_VERSION_, '1.7.0.0', '<')) {
+        if (version_compare(_PS_VERSION_, '1.7.0.0', '<') || version_compare(_PS_VERSION_, '8.0.0', '>=')) {
             return '';
         }
 
         // Display PrestaShop Paylater with PayPlug & Oney only if PrestaShop Checkout is enabled and onboarded for FR & IT located merchant
         if ('AdminPayment' === Tools::getValue('controller')
-            && in_array($this->getShopCountryCode(), ['FR', 'IT'], true)
+            && in_array($this->getShopCountryCode(), ['FR', 'IT', 'ES', 'BE'], true)
             && Module::isEnabled('ps_checkout')
             && Configuration::get('PS_CHECKOUT_PAYPAL_ID_MERCHANT')
         ) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Two new distribution countries added for PS Paylater (Spain, Belgium) and display limitation for PrestaShop 1.7.x (PrestaShop 8.x excluded)
| Type?         | Improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Install the module on PrestaShop 8.x, install PS Checkout, change in ps_configuration the value of PS_CHECKOUT_PAYPAL_ID_MERCHANT, go to Payment Methods in the back-office, the banner should not be displayed. On PrestaShop 1.7, under the same conditions, the banner must be displayed.